### PR TITLE
Relax containers bound; avoid import in newer GHCs.

### DIFF
--- a/compressed.cabal
+++ b/compressed.cabal
@@ -29,7 +29,7 @@ library
 
   build-depends:
     base                   >= 4        && < 5,
-    containers             >= 0.3      && < 0.6,
+    containers             >= 0.3      && < 0.7,
     fingertree             >= 0.0.1    && < 0.2,
     hashable               >= 1.1.2.1  && < 1.3,
     unordered-containers   >= 0.2.1    && < 0.3,

--- a/src/Data/Compressed/RunLengthEncoding.hs
+++ b/src/Data/Compressed/RunLengthEncoding.hs
@@ -35,7 +35,9 @@ module Data.Compressed.RunLengthEncoding
     ) where
 
 import Data.Foldable
+#if __GLASGOW_HASKELL__ < 804
 import Data.Semigroup
+#endif
 import Data.Semigroup.Reducer
 import Data.Semigroup.Foldable
 import Data.Hashable


### PR DESCRIPTION
Tested build with GHC 8.2.2, 8.4.4, 8.6.4, 8.6.5.